### PR TITLE
GP-31625 Limit case subject length based on HTMLInputCoder's behaviour

### DIFF
--- a/tests/phpunit/Civi/Mailutils/Processor/SupportCaseTest.php
+++ b/tests/phpunit/Civi/Mailutils/Processor/SupportCaseTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Civi\Mailutils\Processor;
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Test case subject cutter
+ *
+ * @group headless
+ */
+class SubjectNormalizerTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  public function subjectProvider() {
+    return [
+      ['Foo bar', 'Foo bar'],
+      ['Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Enim', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Enim'],
+      ['Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eni💩', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eni💩'],
+      ['Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut 💩 labore et dolore magna aliqua. Enim', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut 💩 labore et dolore magna aliqua. E…'],
+      ['Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Enim ad', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eni…'],
+      ['', '(no subject)'],
+      ['Lorem <> ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Enim', 'Lorem <> ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna al…'],
+    ];
+  }
+
+  /**
+   * Test that the case subject generator cuts subjects correctly
+   *
+   * @dataProvider subjectProvider
+   *
+   * @param $raw
+   * @param $cut
+   */
+  public function testCaseSubject($raw, $cut) {
+    $this->assertEquals($cut, SupportCase::getCaseSubject($raw));
+  }
+}


### PR DESCRIPTION
CiviCase has a `VARCHAR(128)` subject field. In mailutils, we cut case subjects to 128 characters before creating cases via API4. However, due to Civi's (braindead) internal database HTML encoding method in `CRM_Utils_API_HTMLInputCoder`, raw subjects containing < or > may exceed the 128 character limit once the encoding has been applied.

We need to account for Civi's HTML encoding when determining and adjusting the subject length.